### PR TITLE
add check to change gitconfig for linux diff/merg tool

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -30,10 +30,12 @@ cp .gitconfig ~/.gitconfig
 cp .vimrc ~/.vimrc
 
 # change diff/merge tool to work with beyond compare 3 properly in linux
-#git config --global diff.tool bc3
-#git config --global difftool.bc3.trustExitCode true
-#git config --global merge.tool bc3
-#git config --global mergetool.bc3.trustExitCode true
+if [ "$1" = "nix" ]; then
+  git config --global diff.tool bc3
+  git config --global difftool.bc3.trustExitCode true
+  git config --global merge.tool bc3
+  git config --global mergetool.bc3.trustExitCode true
+fi
 
 # reload bashrc
 . ~/.bashrc


### PR DESCRIPTION
if on unix, passing in 'nix' argument will update git config with proper diff/merge tool.  otherwise gitconfig points to windows file locations for them.